### PR TITLE
fix: update docker event format to use template syntax

### DIFF
--- a/src/utils/localstack-container.ts
+++ b/src/utils/localstack-container.ts
@@ -99,7 +99,7 @@ function listenToContainerStatus(
 				"--filter",
 				"event=die",
 				"--format",
-				"json",
+				"{{json .}}",
 			]);
 
 			dockerEvents.on("error", (error) => {


### PR DESCRIPTION
## Summary

This PR fixes the issue where LocalStack container state in the VSCode extension stays in `starting` or `stopping` and never transitions to `running` or `stopped`.

## my environment
VSCode: Version: 1.104.1
LocalStack Toolkit: 1.2.3
macOS (Apple M1 Pro): Sequoia 15.7
docker: 20.10.21, build baeda1f82a

## Problem

- In my environment, LocalStack state was stuck at `starting` / `stopping`.
- Checking Docker directly (`docker ps`) showed that the container itself had already reached `running` / `stopped`.
- However, the extension did not detect the state transition correctly.

## Investigation

When inspecting Docker events:

```bash
docker events --filter container=localstack-main \
  --filter event=start --filter event=stop --filter event=kill \
  --filter event=die --filter event=restart \
  --format json
```

→ **No events were captured.**

But with:

```bash
docker events --filter container=localstack-main \
  --filter event=start --filter event=stop --filter event=kill \
  --filter event=die --filter event=restart \
  --format '{{json .}}'
```

→ Events were captured correctly (`start`, `stop`, `die`, etc.).

This difference in formatting prevented the extension from correctly updating the container state.

## Fix

- Use `--format '{{json .}}'` when capturing Docker events.
- With this change, the extension correctly updates container state from `starting` → `running` and `stopping` → `stopped`.

## Verification

- Built the extension locally with `make vsix`.
- Installed the generated `.vsix` file in VSCode.
- Verified that LocalStack state now transitions properly between `running` and `stopped`.